### PR TITLE
Dont show log messages for "WuildNinja --version" call

### DIFF
--- a/3rdparty/ninja/src/ninja.cc
+++ b/3rdparty/ninja/src/ninja.cc
@@ -1344,6 +1344,7 @@ NORETURN void real_main(int argc, char** argv) {
   options.input_file = "build.ninja";
   options.dupe_edges_should_err = true;
 
+  Wuild::Syslogger::SetDeferredMode(true);
   Wuild::ConfiguredApplication app(argc, argv, "WuildNinja", "toolClient");
   argc = app.GetRemainArgc();
   argv = app.GetRemainArgv();
@@ -1355,6 +1356,8 @@ NORETURN void real_main(int argc, char** argv) {
   int exit_code = ReadFlags(&argc, &argv, &options, &config);
   if (exit_code >= 0)
     exit(exit_code);
+
+  Wuild::Syslogger::SetDeferredMode(false);
 
   double maxLoad = remoteExecutor.GetMaxLoadAverage();
   if (maxLoad)

--- a/Platform/Syslogger.h
+++ b/Platform/Syslogger.h
@@ -44,6 +44,7 @@ public:
 
 	 /// Change default logging behaviour.
 	static void SetLoggerBackend(std::unique_ptr<ILoggerBackend> && backend);
+	static void SetDeferredMode(bool deferred);
 	static bool IsLogLevelEnabled(int logLevel);
 
 	/// Convenience wrapper for blobs. When outputting to Syslogger, output will be HEX-formatted.


### PR DESCRIPTION
"WuildNinja --version" call should print version only.
Any advanced output will break CMake version detection logic.